### PR TITLE
[feat] Use currently released version in the readme for action

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: grafana/setup-k6-action@v1
+      - uses: grafana/setup-k6-action@v0.0.1
         with:
           k6-version: '0.49.0'
       - run: k6 run script.js --quiet
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: grafana/setup-k6-action@v1
+      - uses: grafana/setup-k6-action@v0.0.1
         with:
           k6-version: '0.49.0'
           browser: true


### PR DESCRIPTION
The readme currently points to `v1` in the examples but the current release version is `v0.0.1` so if anyone tries to copy from the examples their pipeline will fail. 
These changes update the version number for the action to the current release of the action, allowing anyone to follow the readme to test it out. 