### PR TITLE
Add support for setting up K6 in MacOS runner

### DIFF
--- a/.github/workflows/macos-runner-test.yaml
+++ b/.github/workflows/macos-runner-test.yaml
@@ -1,0 +1,22 @@
+name: Workflow using the Grafana k6 setup action on MacOS runner
+on:
+  push:
+
+jobs:
+  protocol:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup Grafana k6
+      uses: ./
+      with:
+        k6-version: '0.49.0'
+    - run: k6 run ./dev/protocol.js --quiet
+
+  use-latest-release:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup Grafana k6
+      uses: ./
+    - run: k6 run ./dev/protocol.js --quiet

--- a/action.yaml
+++ b/action.yaml
@@ -12,6 +12,10 @@ inputs:
   browser:
     description: 'Installs the browser dependencies for k6'
     required: false
+  github-token:
+    description: 'GitHub API Access Token'
+    default: ${{ github.token }}
+    required: false
 
 outputs:
   k6-version:

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,7 @@
 import * as core from '@actions/core';
 import * as exec from '@actions/exec';
 import * as tc from '@actions/tool-cache';
-import { Octokit } from "@octokit/rest";
-import chmodr from 'chmodr';
-import * as fs from 'fs-extra';
+import { setupk6 } from './k6';
 
 run()
 
@@ -32,50 +30,6 @@ export async function run(): Promise<void> {
     } catch (error) {
         if (error instanceof Error) core.setFailed(error.message)
     }
-}
-
-// TODO: Cache the k6 binary and add support for MacOS and Windows
-async function setupk6(version?: string): Promise<string> {
-    let binaryName = ``
-
-    if (!version) {
-        // Get the latest version
-        const octokit = new Octokit();
-        const { data } = await octokit.repos.getLatestRelease({
-            owner: 'grafana',
-            repo: 'k6'
-        })
-        if (data.tag_name[0] === 'v') {
-            version = data.tag_name.slice(1) // remove the 'v' prefix from the version string
-        } else {
-            version = data.tag_name
-        }
-    }
-
-    if (process.arch === "x64") {
-        binaryName = `k6-v${version}-linux-amd64`
-    } else if (process.arch === "arm64") {
-        binaryName = `k6-v${version}-linux-arm64`
-    } else {
-        throw new Error('Unsupported architecture: ' + process.arch)
-    }
-
-    const download = await tc.downloadTool(`https://github.com/grafana/k6/releases/download/v${version}/${binaryName}.tar.gz`)
-    const extractedPath = await tc.extractTar(download)
-
-    const extractedBinaryPath = `${extractedPath}/${binaryName}`
-    const binaryPath = `${extractedPath}/k6`
-    fs.renameSync(extractedBinaryPath, binaryPath)
-
-    chmodr(binaryPath, 0o0755, err => {
-        if (err) {
-            throw err
-        }
-    })
-
-    core.addPath(binaryPath)
-
-    return binaryPath
 }
 
 // TODO: Support MacOS and Windows

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,9 +14,6 @@ export async function run(): Promise<void> {
         const k6_version = core.getInput('k6-version', { required: false })
         const browser = core.getInput('browser') === 'true'
 
-        if (process.platform !== 'linux') {
-            throw new Error('Unsupported platform: ' + process.platform)
-        }
         if (process.arch === 'arm64' && browser) {
             throw new Error('Browser is not supported on arm64')
         }

--- a/src/k6.ts
+++ b/src/k6.ts
@@ -14,7 +14,10 @@ const SUPPORTED_OS_TO_ARCH_MAP: { [key: string]: Arch[] } = {
 
 async function getLatestK6Version(): Promise<string> {
     let version = '';
-    const octokit = new Octokit();
+    const token = core.getInput('github-token', { required: false });
+    const octokit = new Octokit({
+        auth: token
+    });
     const { data } = await octokit.repos.getLatestRelease({
         owner: 'grafana',
         repo: 'k6'

--- a/src/k6.ts
+++ b/src/k6.ts
@@ -1,0 +1,100 @@
+// Module to setup k6
+import * as core from '@actions/core';
+import * as tc from '@actions/tool-cache';
+import { Octokit } from "@octokit/rest";
+import chmodr from 'chmodr';
+import { renameSync } from 'fs-extra';
+import { Arch, getPlatform } from "./platform";
+
+interface SetupK6 {
+    setupk6(version?: string): Promise<string>
+}
+
+const BaseK6DownloadURL = 'https://github.com/grafana/k6/releases/download/'
+
+async function getLatestK6Version(): Promise<string> {
+    let version = '';
+    const octokit = new Octokit();
+    const { data } = await octokit.repos.getLatestRelease({
+        owner: 'grafana',
+        repo: 'k6'
+    })
+    if (data.tag_name[0] === 'v') {
+        version = data.tag_name.slice(1) // remove the 'v' prefix from the version string
+    } else {
+        version = data.tag_name
+    }
+
+    core.debug(`Latest k6 version is ${version}`)
+
+    return version
+}
+
+/**
+ * Adds the k6 binary in the PATH allowing to use `k6` directly in the workflow
+ *
+ * @param {string} extractedPath - The path where the downloaded k6 binary is located
+ * @param {string} binaryName - The name of the downloaded k6 binary
+ *
+ * @returns {string} Complete path where the k6 binary is located and can be used from
+ */
+function addK6InPath(extractedPath: string, binaryName: string) {
+    const downloadedK6BinaryPath = `${extractedPath}/${binaryName}`
+    const expectedPath = `${downloadedK6BinaryPath}/k6`
+
+    renameSync(downloadedK6BinaryPath, expectedPath)
+
+    chmodr(expectedPath, 0o0755, err => {
+        if (err) {
+            throw err
+        }
+    })
+
+    core.addPath(expectedPath)
+
+    return expectedPath
+}
+
+class Linux implements SetupK6 {
+    async setupk6(version?: string): Promise<string> {
+        let binaryName = ``
+        const platform = getPlatform()
+
+        if (!version) {
+            // Get the latest version
+            version = await getLatestK6Version()
+        }
+
+        if (platform.arch === Arch.AMD64) {
+            binaryName = `k6-v${version}-linux-amd64`
+        } else if (platform.arch === Arch.ARM64) {
+            binaryName = `k6-v${version}-linux-arm64`
+        } else {
+            throw new Error('Unsupported architecture for linux: ' + platform.arch)
+        }
+
+        const downloadUrl = `${BaseK6DownloadURL}v${version}/${binaryName}.tar.gz`
+
+        core.debug(`Downloading k6 from ${downloadUrl}`)
+
+        const download = await tc.downloadTool(downloadUrl)
+        const extractedPath = await tc.extractTar(download)
+
+        const k6executablePath = addK6InPath(extractedPath, binaryName);
+
+        return k6executablePath;
+    }
+}
+
+export async function setupk6(version?: string): Promise<string> {
+    const platform = getPlatform();
+    let k6SetupClass: SetupK6;
+
+    if (platform.os === 'linux') {
+        k6SetupClass = new Linux();
+    } else {
+        throw new Error(`Unsupported platform: ${platform.os}`);
+    }
+
+    return k6SetupClass.setupk6(version);
+}

--- a/src/k6.ts
+++ b/src/k6.ts
@@ -4,13 +4,13 @@ import * as tc from '@actions/tool-cache';
 import { Octokit } from "@octokit/rest";
 import chmodr from 'chmodr';
 import { renameSync } from 'fs-extra';
-import { Arch, getPlatform } from "./platform";
+import { Arch, getPlatform, OS } from "./platform";
 
-interface SetupK6 {
-    setupk6(version?: string): Promise<string>
+const BaseK6DownloadURL = 'https://github.com/grafana/k6/releases/download'
+const SUPPORTED_OS_TO_ARCH_MAP: { [key: string]: Arch[] } = {
+    [OS.LINUX]: [Arch.AMD64, Arch.ARM64],
+    [OS.DARWIN]: [Arch.AMD64, Arch.ARM64],
 }
-
-const BaseK6DownloadURL = 'https://github.com/grafana/k6/releases/download/'
 
 async function getLatestK6Version(): Promise<string> {
     let version = '';
@@ -31,6 +31,29 @@ async function getLatestK6Version(): Promise<string> {
 }
 
 /**
+ * Downloads and extracts the k6 binary for the given version, OS and architecture
+ *
+ * @param {string} version - The version of k6 to download
+ * @param {OS} os - The OS for which to download the k6 binary
+ * @param {Arch} architecture - The architecture for which to download the k6 binary
+ * @return {*}  {Promise<[string, string]>} The path where the k6 binary is extracted and the name of the binary
+ */
+async function downloadAndExtractK6Binary(version: string, os: OS, architecture: Arch): Promise<[string, string]> {
+    const k6BinaryName = `k6-v${version}-${os}-${architecture}`
+    const zipExtension = os === OS.LINUX ? 'tar.gz' : 'zip'
+    const downloadUrl = `${BaseK6DownloadURL}/v${version}/${k6BinaryName}.${zipExtension}`
+
+    core.debug(`Downloading k6 from ${downloadUrl}`)
+
+
+    const download = await tc.downloadTool(downloadUrl)
+    const extractedPath = await tc.extractTar(download)
+
+    return [extractedPath, k6BinaryName]
+}
+
+
+/**
  * Adds the k6 binary in the PATH allowing to use `k6` directly in the workflow
  *
  * @param {string} extractedPath - The path where the downloaded k6 binary is located
@@ -39,8 +62,9 @@ async function getLatestK6Version(): Promise<string> {
  * @returns {string} Complete path where the k6 binary is located and can be used from
  */
 function addK6InPath(extractedPath: string, binaryName: string) {
+    // Rename .../k6-vX.Y.Z-OS-ARCH to .../k6
     const downloadedK6BinaryPath = `${extractedPath}/${binaryName}`
-    const expectedPath = `${downloadedK6BinaryPath}/k6`
+    const expectedPath = `${extractedPath}/k6`
 
     renameSync(downloadedK6BinaryPath, expectedPath)
 
@@ -55,46 +79,29 @@ function addK6InPath(extractedPath: string, binaryName: string) {
     return expectedPath
 }
 
-class Linux implements SetupK6 {
-    async setupk6(version?: string): Promise<string> {
-        let binaryName = ``
-        const platform = getPlatform()
-
-        if (!version) {
-            // Get the latest version
-            version = await getLatestK6Version()
-        }
-
-        if (platform.arch === Arch.AMD64) {
-            binaryName = `k6-v${version}-linux-amd64`
-        } else if (platform.arch === Arch.ARM64) {
-            binaryName = `k6-v${version}-linux-arm64`
-        } else {
-            throw new Error('Unsupported architecture for linux: ' + platform.arch)
-        }
-
-        const downloadUrl = `${BaseK6DownloadURL}v${version}/${binaryName}.tar.gz`
-
-        core.debug(`Downloading k6 from ${downloadUrl}`)
-
-        const download = await tc.downloadTool(downloadUrl)
-        const extractedPath = await tc.extractTar(download)
-
-        const k6executablePath = addK6InPath(extractedPath, binaryName);
-
-        return k6executablePath;
-    }
-}
-
 export async function setupk6(version?: string): Promise<string> {
     const platform = getPlatform();
-    let k6SetupClass: SetupK6;
 
-    if (platform.os === 'linux') {
-        k6SetupClass = new Linux();
-    } else {
+    core.debug(`Setting up k6 for ${platform.os} ${platform.arch}`)
+
+    if (!(platform.os in SUPPORTED_OS_TO_ARCH_MAP)) {
         throw new Error(`Unsupported platform: ${platform.os}`);
     }
 
-    return k6SetupClass.setupk6(version);
+    const supportedArchitectures = SUPPORTED_OS_TO_ARCH_MAP[platform.os];
+
+    if (!supportedArchitectures.includes(platform.arch)) {
+        throw new Error(`Unsupported architecture: ${platform.arch}. Supported architectures for ${platform.os} are: ${supportedArchitectures}`);
+    }
+
+    if (!version) {
+        // Get the latest version
+        version = await getLatestK6Version()
+    }
+
+    const [extractedPath, binaryName] = await downloadAndExtractK6Binary(version, platform.os, platform.arch)
+
+    const k6executablePath = addK6InPath(extractedPath, binaryName);
+
+    return k6executablePath;
 }

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -1,0 +1,59 @@
+// Taken from https://github.com/browser-actions/setup-chrome/blob/master/src/platform.ts
+
+import os from "node:os";
+
+export type Platform = {
+    os: OS;
+    arch: Arch;
+};
+
+export const OS = {
+    DARWIN: "macos",
+    LINUX: "linux",
+    WINDOWS: "windows",
+} as const;
+
+// eslint-disable-next-line no-redeclare
+export type OS = (typeof OS)[keyof typeof OS];
+
+export const Arch = {
+    AMD64: "amd64",
+    I686: "i686",
+    ARM64: "arm64",
+} as const;
+
+// eslint-disable-next-line no-redeclare
+export type Arch = (typeof Arch)[keyof typeof Arch];
+
+export const getOS = (): OS => {
+    const platform = os.platform();
+    switch (platform) {
+        case "linux":
+            return OS.LINUX;
+        case "darwin":
+            return OS.DARWIN;
+        case "win32":
+            return OS.WINDOWS;
+    }
+    throw new Error(`Unsupported platform: ${platform}`);
+};
+
+export const getArch = (): Arch => {
+    const arch = os.arch();
+    switch (arch) {
+        case "x32":
+            return Arch.I686;
+        case "x64":
+            return Arch.AMD64;
+        case "arm64":
+            return Arch.ARM64;
+    }
+    throw new Error(`Unsupported arch: ${arch}`);
+};
+
+export const getPlatform = (): Platform => {
+    return {
+        os: getOS(),
+        arch: getArch(),
+    };
+};


### PR DESCRIPTION
- Add a new module to work with different OS and architectures properly 
- Abstract out the logic for setting up k6 in a separate module. 
- Add support for setting up k6 in MacOS runners 
- Use default Github token present in pipeline to search for latest k6 version
