### PR TITLE
Add Browser support for MacOS runners

### DIFF
--- a/.github/workflows/macos-runner-test.yaml
+++ b/.github/workflows/macos-runner-test.yaml
@@ -13,6 +13,17 @@ jobs:
         k6-version: '0.49.0'
     - run: k6 run ./dev/protocol.js --quiet
 
+  browser:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup Grafana k6
+      uses: ./
+      with:
+        k6-version: '0.49.0'
+        browser: true
+    - run: k6 run ./dev/browser.js --quiet
+
   use-latest-release:
     runs-on: macos-latest
     steps:

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1,0 +1,106 @@
+// Module to verify and setup the browser
+import * as core from '@actions/core';
+import * as exec from '@actions/exec';
+import * as tc from '@actions/tool-cache';
+import { OS, getPlatform } from './platform';
+
+interface Browser {
+    checkChromeInstalled(): Promise<boolean>
+    setupBrowser(): Promise<void>
+}
+
+
+class Macos implements Browser {
+    async checkChromeInstalled(): Promise<boolean> {
+        let myOutput = '', myError = '', options = {
+            listeners: {
+                stdout: (data: Buffer) => {
+                    myOutput += data.toString();
+                },
+                stderr: (data: Buffer) => {
+                    myError += data.toString();
+                }
+            }
+        };
+        try {
+            await exec.exec(`mdfind "kMDItemCFBundleIdentifier == 'com.google.Chrome'"`, [], options);
+        } catch (error) {
+            return false;
+        }
+
+        if (myOutput.includes('Chrome.app')) {
+            return true;
+        }
+
+        return false;
+    }
+
+    async setupBrowser(): Promise<void> {
+        await exec.exec('brew', ['install', '--cask', 'google-chrome']);
+    }
+}
+
+class Linux implements Browser {
+    async checkChromeInstalled(): Promise<boolean> {
+        let myOutput = '', myError = '', options = {
+            listeners: {
+                stdout: (data: Buffer) => {
+                    myOutput += data.toString();
+                },
+                stderr: (data: Buffer) => {
+                    myError += data.toString();
+                }
+            }
+        };
+        try {
+            await exec.exec(`google-chrome`, ['--version'], options);
+        } catch (error) {
+            return false;
+        }
+
+        if (myOutput.includes('Google Chrome')) {
+            return true;
+        }
+        return false;
+    }
+
+    async setupBrowser(): Promise<void> {
+        const downloadKey = await tc.downloadTool('https://dl-ssl.google.com/linux/linux_signing_key.pub')
+        await exec.exec(`sudo apt-key add ${downloadKey}`)
+        await exec.exec(`sudo sh -c "echo 'deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main' >> /etc/apt/sources.list.d/google-chrome.list"`)
+        await exec.exec('sudo apt-get update')
+        await exec.exec('sudo apt-get install -y google-chrome-stable')
+    }
+}
+
+
+export async function initialiseBrowser(): Promise<void> {
+    const platform = getPlatform();
+    let browserSetupClass: Browser;
+
+    if (platform.os === OS.DARWIN) {
+        browserSetupClass = new Macos();
+    } else if (platform.os === OS.LINUX) {
+        browserSetupClass = new Linux();
+    } else {
+        throw new Error(`Unsupported platform: ${platform.os}`);
+    }
+
+    // Check if browser is already installed
+    const isBrowserInstalled = await browserSetupClass.checkChromeInstalled();
+
+    if (isBrowserInstalled) {
+        core.info('Browser is already installed, skipping installation');
+        return;
+    }
+
+    // Install browser
+    core.debug('Installing browser');
+    await browserSetupClass.setupBrowser();
+
+    // Check if browser is installed
+    const isBrowserInstalledAfterSetup = await browserSetupClass.checkChromeInstalled();
+    if (!isBrowserInstalledAfterSetup) {
+        throw new Error('Failed to install browser');
+    }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
 import * as core from '@actions/core';
-import * as exec from '@actions/exec';
-import * as tc from '@actions/tool-cache';
+import { initialiseBrowser } from './browser';
 import { setupk6 } from './k6';
 
 run()
@@ -14,26 +13,13 @@ export async function run(): Promise<void> {
         const k6_version = core.getInput('k6-version', { required: false })
         const browser = core.getInput('browser') === 'true'
 
-        if (process.arch === 'arm64' && browser) {
-            throw new Error('Browser is not supported on arm64')
-        }
-
         await setupk6(k6_version)
 
         if (browser) {
             core.exportVariable('K6_BROWSER_ARGS', 'no-sandbox')
-            await setupBrowser()
+            await initialiseBrowser();
         }
     } catch (error) {
         if (error instanceof Error) core.setFailed(error.message)
     }
-}
-
-// TODO: Support MacOS and Windows
-async function setupBrowser(): Promise<void> {
-    const downloadKey = await tc.downloadTool('https://dl-ssl.google.com/linux/linux_signing_key.pub')
-    await exec.exec(`sudo apt-key add ${downloadKey}`)
-    await exec.exec(`sudo sh -c "echo 'deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main' >> /etc/apt/sources.list.d/google-chrome.list"`)
-    await exec.exec('sudo apt-get update')
-    await exec.exec('sudo apt-get install -y google-chrome-stable')
 }


### PR DESCRIPTION
- Abstract out browser initialisation in separate module 
- Check if browser is already present on the machine before trying to install it. 