### PR TITLE
Add support for windows runners 

### DIFF
--- a/.github/workflows/linux-runner-test.yaml
+++ b/.github/workflows/linux-runner-test.yaml
@@ -1,4 +1,4 @@
-name: Workflow using the Grafana k6 setup action
+name: Test on Linux runner
 on:
   push:
 
@@ -12,7 +12,7 @@ jobs:
       with:
         k6-version: '0.49.0'
     - run: k6 run ./dev/protocol.js --quiet
-    
+
   browser:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/macos-runner-test.yaml
+++ b/.github/workflows/macos-runner-test.yaml
@@ -1,4 +1,4 @@
-name: Workflow using the Grafana k6 setup action on MacOS runner
+name: Test on MacOS runner
 on:
   push:
 

--- a/.github/workflows/windows-runner-test.yaml
+++ b/.github/workflows/windows-runner-test.yaml
@@ -12,7 +12,7 @@ jobs:
       with:
         k6-version: '0.49.0'
     - name: Check if correct k6 version is installed
-      run: k6 --version | findstr "0.48.0"
+      run: k6 --version | findstr "0.49.0"
     - run: k6 run ./dev/protocol.js --quiet
 
   use-latest-release:

--- a/.github/workflows/windows-runner-test.yaml
+++ b/.github/workflows/windows-runner-test.yaml
@@ -1,0 +1,35 @@
+name: Workflow using the Grafana k6 setup action on Windows runner
+on:
+  push:
+
+jobs:
+  protocol:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup Grafana k6
+      uses: ./
+      with:
+        k6-version: '0.49.0'
+    - name: Check if correct k6 version is installed
+      run: k6 --version | findstr "0.48.0"
+    - run: k6 run ./dev/protocol.js --quiet
+
+  use-latest-release:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup Grafana k6
+      uses: ./
+    - run: k6 run ./dev/protocol.js --quiet
+
+  browser:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup Grafana k6
+      uses: ./
+      with:
+        k6-version: '0.49.0'
+        browser: true
+    - run: k6 run ./dev/browser.js --quiet

--- a/.github/workflows/windows-runner-test.yaml
+++ b/.github/workflows/windows-runner-test.yaml
@@ -1,4 +1,4 @@
-name: Workflow using the Grafana k6 setup action on Windows runner
+name: Test on Windows runner
 on:
   push:
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-  
+
   <img
     src="./k6.gif"
     width="600"
@@ -18,25 +18,23 @@ This action sets up a Grafana k6 environment for use in a GitHub Actions workflo
 - Installing Chrome for Browser Testing (optional).
 
 
-After that we can use the [run-k6-action](https://github.com/grafana/run-k6-action/) to execute the k6 tests in the GitHub Actions workflow. 
+After that we can use the [run-k6-action](https://github.com/grafana/run-k6-action/) to execute the k6 tests in the GitHub Actions workflow.
 
-> ⚠️ This action only supports Linux runners ⚠️
-
-## Inputs 
+## Inputs
 
 The following inputs can be used as `step.with` key:
 
-| Name | Type | Required | Description 
-| --- | --- | --- | --- |
-| `k6-version` | string | `false` | Specify the k6 version to use. e.g. `'0.49.0'`. If not set, latest K6 version will be used. 
-| `browser` | boolean |  `false` | Default `false`. If set to `true` chrome is also installed along with K6 for Browser testing. 
+| Name         | Type    | Required | Description                                                                                   |
+| ------------ | ------- | -------- | --------------------------------------------------------------------------------------------- |
+| `k6-version` | string  | `false`  | Specify the k6 version to use. e.g. `'0.49.0'`. If not set, latest K6 version will be used.   |
+| `browser`    | boolean | `false`  | Default `false`. If set to `true` chrome is also installed along with K6 for Browser testing. |
 
 
 ## Usage
 
-Following are some examples of using the workflow. 
+Following are some examples of using the workflow.
 
-### Basic 
+### Basic
 
 Uses the latest k6 version
 
@@ -56,7 +54,7 @@ jobs:
             ./tests/api*.js
 ```
 
-Specify which k6 version to use 
+Specify which k6 version to use
 
 ```yaml
 on:

--- a/dist/index.js
+++ b/dist/index.js
@@ -35586,6 +35586,33 @@ class Macos {
         await exec.exec('brew', ['install', '--cask', 'google-chrome']);
     }
 }
+class Windows {
+    async checkChromeInstalled() {
+        let myOutput = '', myError = '', options = {
+            listeners: {
+                stdout: (data) => {
+                    myOutput += data.toString();
+                },
+                stderr: (data) => {
+                    myError += data.toString();
+                }
+            }
+        };
+        try {
+            await exec.exec('choco', ['list', '-i'], options);
+        }
+        catch (error) {
+            return false;
+        }
+        if (myOutput.includes('Google Chrome|')) {
+            return true;
+        }
+        return false;
+    }
+    async setupBrowser() {
+        await exec.exec('choco', ['install', 'googlechrome', '-y']);
+    }
+}
 class Linux {
     async checkChromeInstalled() {
         let myOutput = '', myError = '', options = {
@@ -35625,6 +35652,9 @@ async function initialiseBrowser() {
     }
     else if (platform.os === platform_1.OS.LINUX) {
         browserSetupClass = new Linux();
+    }
+    else if (platform.os === platform_1.OS.WINDOWS) {
+        browserSetupClass = new Windows();
     }
     else {
         throw new Error(`Unsupported platform: ${platform.os}`);
@@ -35751,6 +35781,7 @@ const BaseK6DownloadURL = 'https://github.com/grafana/k6/releases/download';
 const SUPPORTED_OS_TO_ARCH_MAP = {
     [platform_1.OS.LINUX]: [platform_1.Arch.AMD64, platform_1.Arch.ARM64],
     [platform_1.OS.DARWIN]: [platform_1.Arch.AMD64, platform_1.Arch.ARM64],
+    [platform_1.OS.WINDOWS]: [platform_1.Arch.AMD64]
 };
 async function getLatestK6Version() {
     let version = '';

--- a/dist/index.js
+++ b/dist/index.js
@@ -35559,28 +35559,43 @@ const core = __importStar(__nccwpck_require__(2186));
 const exec = __importStar(__nccwpck_require__(1514));
 const tc = __importStar(__nccwpck_require__(7784));
 const platform_1 = __nccwpck_require__(2999);
+/**
+ * Check if the browser is installed
+ *
+ * @param {string} command - The command to check if the browser is installed
+ * @param {string[]} args - The arguments to pass to the command
+ * @param {string} checkString - The string to check in the output of the command
+ *
+ * @return {*}  {Promise<boolean>} - Returns true if the browser is installed, false otherwise
+ */
+async function checkIfBrowserInstalled(command, args, checkString) {
+    let myOutput = '', myError = '', options = {
+        listeners: {
+            stdout: (data) => {
+                myOutput += data.toString();
+            },
+            stderr: (data) => {
+                myError += data.toString();
+            }
+        }
+    };
+    try {
+        await exec.exec(command, args, options);
+        core.debug(`~checkIfBrowserInstalled~ Output: ${myOutput}`);
+        core.debug(`~checkIfBrowserInstalled~ Error: ${myError}`);
+    }
+    catch (error) {
+        core.error(`Error in checking chrome version: ${error}`);
+        return false;
+    }
+    if (myOutput.includes(checkString)) {
+        return true;
+    }
+    return false;
+}
 class Macos {
     async checkChromeInstalled() {
-        let myOutput = '', myError = '', options = {
-            listeners: {
-                stdout: (data) => {
-                    myOutput += data.toString();
-                },
-                stderr: (data) => {
-                    myError += data.toString();
-                }
-            }
-        };
-        try {
-            await exec.exec(`mdfind "kMDItemCFBundleIdentifier == 'com.google.Chrome'"`, [], options);
-        }
-        catch (error) {
-            return false;
-        }
-        if (myOutput.includes('Chrome.app')) {
-            return true;
-        }
-        return false;
+        return await checkIfBrowserInstalled(`mdfind "kMDItemCFBundleIdentifier == 'com.google.Chrome'"`, [], 'Chrome.app');
     }
     async setupBrowser() {
         await exec.exec('brew', ['install', '--cask', 'google-chrome']);
@@ -35588,26 +35603,7 @@ class Macos {
 }
 class Windows {
     async checkChromeInstalled() {
-        let myOutput = '', myError = '', options = {
-            listeners: {
-                stdout: (data) => {
-                    myOutput += data.toString();
-                },
-                stderr: (data) => {
-                    myError += data.toString();
-                }
-            }
-        };
-        try {
-            await exec.exec('choco', ['list', '-i'], options);
-        }
-        catch (error) {
-            return false;
-        }
-        if (myOutput.includes('Google Chrome|')) {
-            return true;
-        }
-        return false;
+        return await checkIfBrowserInstalled('choco', ['list', '-i'], 'Google Chrome|');
     }
     async setupBrowser() {
         await exec.exec('choco', ['install', 'googlechrome', '-y']);
@@ -35615,26 +35611,7 @@ class Windows {
 }
 class Linux {
     async checkChromeInstalled() {
-        let myOutput = '', myError = '', options = {
-            listeners: {
-                stdout: (data) => {
-                    myOutput += data.toString();
-                },
-                stderr: (data) => {
-                    myError += data.toString();
-                }
-            }
-        };
-        try {
-            await exec.exec(`google-chrome`, ['--version'], options);
-        }
-        catch (error) {
-            return false;
-        }
-        if (myOutput.includes('Google Chrome')) {
-            return true;
-        }
-        return false;
+        return await checkIfBrowserInstalled('google-chrome', ['--version'], 'Google Chrome');
     }
     async setupBrowser() {
         const downloadKey = await tc.downloadTool('https://dl-ssl.google.com/linux/linux_signing_key.pub');
@@ -35666,7 +35643,7 @@ async function initialiseBrowser() {
         return;
     }
     // Install browser
-    core.debug('Installing browser');
+    core.info('Installing browser');
     await browserSetupClass.setupBrowser();
     // Check if browser is installed
     const isBrowserInstalledAfterSetup = await browserSetupClass.checkChromeInstalled();
@@ -35814,7 +35791,7 @@ async function downloadAndExtractK6Binary(version, os, architecture) {
     const k6BinaryName = `k6-v${version}-${os}-${architecture}`;
     const zipExtension = os === platform_1.OS.LINUX ? 'tar.gz' : 'zip';
     const downloadUrl = `${BaseK6DownloadURL}/v${version}/${k6BinaryName}.${zipExtension}`;
-    core.debug(`Downloading k6 from ${downloadUrl}`);
+    core.info(`Downloading k6 version ${version} from ${downloadUrl} for ${os} ${architecture}`);
     const download = await tc.downloadTool(downloadUrl);
     const extractedPath = await tc.extractTar(download);
     return [extractedPath, k6BinaryName];

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -40,6 +40,36 @@ class Macos implements Browser {
     }
 }
 
+class Windows implements Browser {
+    async checkChromeInstalled(): Promise<boolean> {
+        let myOutput = '', myError = '', options = {
+            listeners: {
+                stdout: (data: Buffer) => {
+                    myOutput += data.toString();
+                },
+                stderr: (data: Buffer) => {
+                    myError += data.toString();
+                }
+            }
+        };
+        try {
+            await exec.exec('choco', ['list', '-i'], options);
+        } catch (error) {
+            return false;
+        }
+
+        if (myOutput.includes('Google Chrome|')) {
+            return true;
+        }
+
+        return false;
+    }
+
+    async setupBrowser(): Promise<void> {
+        await exec.exec('choco', ['install', 'googlechrome', '-y']);
+    }
+}
+
 class Linux implements Browser {
     async checkChromeInstalled(): Promise<boolean> {
         let myOutput = '', myError = '', options = {
@@ -82,6 +112,8 @@ export async function initialiseBrowser(): Promise<void> {
         browserSetupClass = new Macos();
     } else if (platform.os === OS.LINUX) {
         browserSetupClass = new Linux();
+    } else if (platform.os === OS.WINDOWS) {
+        browserSetupClass = new Windows();
     } else {
         throw new Error(`Unsupported platform: ${platform.os}`);
     }

--- a/src/k6.ts
+++ b/src/k6.ts
@@ -47,7 +47,7 @@ async function downloadAndExtractK6Binary(version: string, os: OS, architecture:
     const zipExtension = os === OS.LINUX ? 'tar.gz' : 'zip'
     const downloadUrl = `${BaseK6DownloadURL}/v${version}/${k6BinaryName}.${zipExtension}`
 
-    core.debug(`Downloading k6 from ${downloadUrl}`)
+    core.info(`Downloading k6 version ${version} from ${downloadUrl} for ${os} ${architecture}`)
 
 
     const download = await tc.downloadTool(downloadUrl)

--- a/src/k6.ts
+++ b/src/k6.ts
@@ -7,9 +7,10 @@ import { renameSync } from 'fs-extra';
 import { Arch, getPlatform, OS } from "./platform";
 
 const BaseK6DownloadURL = 'https://github.com/grafana/k6/releases/download'
-const SUPPORTED_OS_TO_ARCH_MAP: { [key: string]: Arch[] } = {
+const SUPPORTED_OS_TO_ARCH_MAP: { [key in OS]: Arch[] } = {
     [OS.LINUX]: [Arch.AMD64, Arch.ARM64],
     [OS.DARWIN]: [Arch.AMD64, Arch.ARM64],
+    [OS.WINDOWS]: [Arch.AMD64]
 }
 
 async function getLatestK6Version(): Promise<string> {


### PR DESCRIPTION
- Adds support for windows runner for protocol and browser tests 
- Adds better abstraction for checking if the browser is installed in the pipeline or not 
- Update readme to remove warning that action is supported only on Linux runners
