### PR TITLE
Add renovate config to compile TS files on PRs

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -35346,7 +35346,9 @@ async function checkIfBrowserInstalled(command, args, checkString) {
 }
 class Macos {
     async checkChromeInstalled() {
-        return await checkIfBrowserInstalled(`mdfind "kMDItemCFBundleIdentifier == 'com.google.Chrome'"`, [], 'Chrome.app');
+        // Check for Chrome.app in the standard location where Homebrew installs it
+        // Use ls to check if the directory exists (more reliable than mdfind which depends on Spotlight indexing)
+        return await checkIfBrowserInstalled('ls', ['-d', '/Applications/Google Chrome.app'], 'Google Chrome.app');
     }
     async setupBrowser() {
         await exec.exec('brew', ['install', '--cask', 'google-chrome']);

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>grafana/grafana-renovate-config//presets/k6/k6-cloud-common"
+  ]
+}

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,10 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "github>grafana/grafana-renovate-config//presets/k6/k6-cloud-common"
-  ]
+  ],
+  "postUpgradeTasks": {
+    "commands": ["npm ci", "npm run package"],
+    "fileFilters": ["dist/**", "package-lock.json"],
+    "executionMode": "branch"
+  }
 }

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -48,7 +48,9 @@ async function checkIfBrowserInstalled(command: string, args: string[], checkStr
 
 class Macos implements Browser {
     async checkChromeInstalled(): Promise<boolean> {
-        return await checkIfBrowserInstalled(`mdfind "kMDItemCFBundleIdentifier == 'com.google.Chrome'"`, [], 'Chrome.app');
+        // Check for Chrome.app in the standard location where Homebrew installs it
+        // Use ls to check if the directory exists (more reliable than mdfind which depends on Spotlight indexing)
+        return await checkIfBrowserInstalled('ls', ['-d', '/Applications/Google Chrome.app'], 'Google Chrome.app');
     }
 
     async setupBrowser(): Promise<void> {


### PR DESCRIPTION
Reference - https://github.com/grafana/run-k6-action/blob/main/renovate.json 

These changes allow Renovate to compile the TS files for the PRs 