### PR TITLE
fix: authenticate git push in move-major-tag workflow

### DIFF
--- a/.github/workflows/move-major-release-tag.yaml
+++ b/.github/workflows/move-major-release-tag.yaml
@@ -14,13 +14,19 @@ jobs:
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
-        persist-credentials: false
+        persist-credentials: true
 
     - name: Get major version number and update tag
       run: |
         VERSION=${GITHUB_REF#refs/tags/}
         MAJOR=${VERSION%%.*}
-        git config --global user.name "${GITHUB_ACTOR}"
-        git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+        git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
+        git config user.name "${GITHUB_ACTOR}"
+        git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
         git tag -fa ${MAJOR} -m "Update major version tag"
         git push origin ${MAJOR} --force
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_ACTOR: ${{ github.actor }}
+        GITHUB_REPOSITORY: ${{ github.repository }}
+        GITHUB_REF: ${{ github.ref }}


### PR DESCRIPTION
Remove persist-credentials: false from checkout (which blocked auth) and instead pass GITHUB_TOKEN explicitly in the push URL so the force-push of the major version tag succeeds.