### PR TITLE
Register Component into Software Catalog and set up TechDocs publishing

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,13 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: setup-k6-action
+  title: setup-k6-action
+  description: |
+    GitHub Action for installing Grafana k6
+  annotations:
+    github.com/project-slug: grafana/setup-k6-action
+spec:
+  type: library
+  owner: group:default/k6-cloud-provisioning
+  lifecycle: production


### PR DESCRIPTION
# Register Component into Software Catalog and set up TechDocs publishing
This PR adds the files to:

* enable EngHub to catalog this service
* set up TechDocs site and publishing

Copy of https://github.com/grafana/setup-k6-action/pull/20 The bot can't sign the CLA.